### PR TITLE
Fix HACS License badge link (use absolute URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub Release](https://img.shields.io/github/release/ruaan-deysel/ha-unraid-management-agent.svg)](https://github.com/ruaan-deysel/ha-unraid-management-agent/releases)
-[![License](https://img.shields.io/github/license/ruaan-deysel/ha-unraid-management-agent.svg)](../LICENSE)
+[![License](https://img.shields.io/github/license/ruaan-deysel/ha-unraid-management-agent.svg)](https://github.com/ruaan-deysel/ha-unraid-management-agent/blob/main/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ruaan-deysel/ha-unraid-management-agent)
 
 Complete Home Assistant custom integration for monitoring and controlling Unraid servers via the Unraid Management Agent.
@@ -484,4 +484,4 @@ Contributions are welcome! Please:
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/ruaan-deysel/ha-unraid-management-agent/blob/main/LICENSE) file for details.


### PR DESCRIPTION
## Summary
- Fix License badge/link in README to use absolute GitHub URL instead of relative path
- Prevents HACS from resolving the link against Home Assistant base URL (e.g., http://<ha-ip>/LICENSE or typos like /licencse)

## Rationale
HACS renders README content within Home Assistant; relative links can be interpreted relative to the HA instance, leading to broken links. Absolute URLs ensure consistent behavior across GitHub and HACS.

No functional code changes.