### PR TITLE
Fix OptionsFlow config_entry property error (HA 2025.x compatibility)

### DIFF
--- a/custom_components/unraid_management_agent/config_flow.py
+++ b/custom_components/unraid_management_agent/config_flow.py
@@ -119,18 +119,14 @@ class UnraidConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
+        _config_entry: config_entries.ConfigEntry,
     ) -> UnraidOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return UnraidOptionsFlowHandler(config_entry)
+        return UnraidOptionsFlowHandler()
 
 
 class UnraidOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Unraid Management Agent."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
This pull request refactors the options flow initialization in the `Unraid Management Agent` integration. The main change is simplifying the way the `UnraidOptionsFlowHandler` is constructed by removing the need to pass the `config_entry` parameter.

Options flow refactor:

* Updated the `async_get_options_flow` method in `config_flow.py` to no longer require the `config_entry` parameter when instantiating `UnraidOptionsFlowHandler`, and removed the corresponding constructor argument and assignment in the `UnraidOptionsFlowHandler` class.