### PR TITLE
feat: add UPS Energy sensor for Energy Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2026.2.0] - 2026-01-29
+## [2026.2.0] - 2026-01-30
 
 ### Added
 
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `is_collector_enabled()` helper method to coordinator for checking collector status
   - If a collector is disabled (e.g., nut, zfs, unassigned), its corresponding entities are not created
   - Reduces entity clutter by only showing relevant entities based on server configuration
+
+- **UPS Energy Sensor**: New `sensor.{hostname}_ups_energy` - Tracks cumulative UPS energy consumption in kWh
+  - Attributes: rated_power (W), load_status, battery_status, estimated_runtime, current_load (%), battery_charge (%)
+  - Uses trapezoidal integration to convert instantaneous power (W) to cumulative energy (kWh)
+  - Compatible with Home Assistant Energy Dashboard for UPS energy monitoring
 
 - **Physical Disk Filtering**: Improved disk entity creation to only include actual physical disks
   - Excludes virtual disks (`docker_vdisk`, `log` roles)

--- a/custom_components/unraid_management_agent/icons.json
+++ b/custom_components/unraid_management_agent/icons.json
@@ -75,10 +75,10 @@
         "default": "mdi:battery"
       },
       "ups_power": {
-        "default": "mdi:power"
+        "default": "mdi:flash"
       },
       "ups_energy": {
-        "default": "mdi:battery"
+        "default": "mdi:lightning-bolt"
       },
       "network_rx": {
         "default": "mdi:ethernet"

--- a/custom_components/unraid_management_agent/strings.json
+++ b/custom_components/unraid_management_agent/strings.json
@@ -93,6 +93,9 @@
       "ups_power": {
         "name": "UPS Power"
       },
+      "ups_energy": {
+        "name": "UPS Energy"
+      },
       "flash_usage": {
         "name": "Flash Usage"
       },

--- a/custom_components/unraid_management_agent/translations/en.json
+++ b/custom_components/unraid_management_agent/translations/en.json
@@ -93,6 +93,9 @@
       "ups_power": {
         "name": "UPS Power"
       },
+      "ups_energy": {
+        "name": "UPS Energy"
+      },
       "flash_usage": {
         "name": "Flash Usage"
       },


### PR DESCRIPTION
- Add UPS Energy sensor with TOTAL_INCREASING state class for Energy Dashboard
- Implement energy calculation using trapezoidal integration from power readings
- Add state restoration using RestoreEntity to persist across restarts
- Include sanity checks to prevent large jumps after long gaps
- Add comprehensive tests for energy sensor functionality
- Update translations and icons for new sensor

The UPS Energy sensor tracks cumulative energy consumption in kWh by integrating power readings over time. This allows users to add both UPS Energy (device energy consumption) and UPS Power (device power consumption) to the Energy Dashboard.