### PR TITLE
fix: rename integration to comply with Unraid trademark policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unraid Management Agent - Home Assistant Integration
+# Management Agent for Unraid® - Home Assistant Integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub Release](https://img.shields.io/github/release/ruaan-deysel/ha-unraid-management-agent.svg)](https://github.com/ruaan-deysel/ha-unraid-management-agent/releases)
@@ -547,3 +547,7 @@ All pull requests must pass:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/ruaan-deysel/ha-unraid-management-agent/blob/main/LICENSE) file for details.
+
+## Trademark Notice
+
+Unraid® is a registered trademark of Lime Technology, Inc. This application is not affiliated with, endorsed, or sponsored by Lime Technology, Inc.

--- a/custom_components/unraid_management_agent/manifest.json
+++ b/custom_components/unraid_management_agent/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "unraid_management_agent",
-  "name": "Unraid Management Agent",
+  "name": "Management Agent for Unraid",
   "codeowners": ["@ruaan-deysel"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/unraid_management_agent/strings.json
+++ b/custom_components/unraid_management_agent/strings.json
@@ -35,7 +35,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Unraid Management Agent Options",
+        "title": "Management Agent for Unraid Options",
         "description": "Configure integration features",
         "data": {
           "enable_websocket": "Enable WebSocket for real-time updates"
@@ -199,7 +199,7 @@
       "message": "Error communicating with Unraid API"
     },
     "no_config_entries": {
-      "message": "No Unraid Management Agent entries configured"
+      "message": "No Management Agent for Unraid entries configured"
     },
     "container_start_failed": {
       "message": "Failed to start container {container_id}"

--- a/custom_components/unraid_management_agent/translations/en.json
+++ b/custom_components/unraid_management_agent/translations/en.json
@@ -35,7 +35,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "Unraid Management Agent Options",
+        "title": "Management Agent for Unraid Options",
         "description": "Configure integration features",
         "data": {
           "enable_websocket": "Enable WebSocket for real-time updates"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Unraid Management Agent",
+  "name": "Management Agent for Unraid",
   "render_readme": true,
   "country": [],
   "homeassistant": "2025.9.0",


### PR DESCRIPTION
- Rename from "Unraid Management Agent" to "Management Agent for Unraid"
  to follow the required "[YourApp] for Unraid®" naming convention
- Add required trademark attribution to README.md
- Update manifest.json, hacs.json, strings.json, and translations

The Unraid Third Party App Naming and Trademark Policy (effective
October 1, 2025) prohibits placing "Unraid" first in app names.

https://claude.ai/code/session_01F8CvLARqA8kvN8vXk5kwVb