### PR TITLE
chore: update changelog and manifest version to 2026.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2026.2.1] - 2026-02-01
+
+### Fixed
+
+- **Name Change**: Changed integration name from "Unraid Management Agent" to "Management Agent for Unraid" in manifest.json and HACS.json to comply with Unraid Third-Party App naming guidelines and policies.
+
 ## [2026.2.0] - 2026-01-30
 
 ### Added

--- a/custom_components/unraid_management_agent/manifest.json
+++ b/custom_components/unraid_management_agent/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ruaan-deysel/ha-unraid-management-agent/issues",
   "loggers": ["uma_api"],
   "requirements": ["uma-api>=1.3.0"],
-  "version": "2026.2.0"
+  "version": "2026.2.1"
 }


### PR DESCRIPTION
This pull request addresses a naming compliance issue by updating the integration name to meet Unraid Third-Party App guidelines. It also bumps the version to reflect this fix.

Naming compliance:

* Changed the integration name from "Unraid Management Agent" to "Management Agent for Unraid" in both `manifest.json` and `HACS.json` to comply with Unraid Third-Party App naming policies.

Version update:

* Updated the version in `manifest.json` from `2026.2.0` to `2026.2.1` to reflect the naming change fix.