### PR TITLE
fix: stop network RX/TX rate sensors flapping to 0 kbit/s

### DIFF
--- a/custom_components/unraid_management_agent/api/calculators.py
+++ b/custom_components/unraid_management_agent/api/calculators.py
@@ -188,6 +188,20 @@ class RateCalculator:
                         else:
                             delta_bytes += self.COUNTER_64_MAX
 
+                    if delta_bytes == 0:
+                        # The counter has not advanced since the last sample.
+                        # This happens whenever the consumer samples faster than
+                        # the source refreshes the counter (e.g. the HA
+                        # coordinator polls every ~30s but the daemon only
+                        # refreshes network counters every ~60s). Computing a
+                        # rate here would report a false 0 and make the sensor
+                        # flap between the real value and 0. Instead, hold the
+                        # previous rate and keep the baseline so the next real
+                        # change is measured over the true elapsed interval.
+                        # A genuinely idle interface is still driven to 0 by the
+                        # stale-threshold branch above once dt grows large enough.
+                        return
+
                     # Convert bytes/sec to kilobits/sec
                     self._rate_kbps = (delta_bytes / dt) * 8 / 1000
 

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -1,0 +1,66 @@
+"""Unit tests for api.calculators.RateCalculator."""
+
+from __future__ import annotations
+
+from custom_components.unraid_management_agent.api import RateCalculator
+
+
+def test_rate_calculator_two_distinct_samples() -> None:
+    """Rate is delta_bytes / dt converted to kbit/s."""
+    calc = RateCalculator()
+    calc.add_sample(0, 0.0)
+    calc.add_sample(125_000, 1.0)  # 125000 B/s * 8 / 1000 = 1000 kbit/s
+    assert calc.rate_kbps == 1000.0
+
+
+def test_rate_calculator_holds_rate_on_unchanged_counter() -> None:
+    """A duplicate sample must not reset the rate to 0 (the flapping bug)."""
+    calc = RateCalculator()
+    calc.add_sample(0, 0.0)
+    calc.add_sample(125_000, 1.0)
+    assert calc.rate_kbps == 1000.0
+
+    # Counter unchanged on the next poll (source hasn't refreshed yet).
+    calc.add_sample(125_000, 2.0)
+    assert calc.rate_kbps == 1000.0  # held, not zeroed
+    # Baseline must NOT advance, so the next real change spans the true interval.
+    assert calc.last_bytes == 125_000
+    assert calc.last_timestamp == 1.0
+
+
+def test_rate_calculator_no_flap_with_fast_polling() -> None:
+    """Polling faster than the counter refreshes yields a steady rate, not 0/value flapping."""
+    calc = RateCalculator()
+    # Counter advances by 6_000_000 bytes every 60s; consumer polls every 30s.
+    samples = [
+        (0, 0.0),
+        (0, 30.0),  # duplicate
+        (6_000_000, 60.0),  # real change -> 6e6/60 * 8 / 1000 = 800 kbit/s
+        (6_000_000, 90.0),  # duplicate
+        (12_000_000, 120.0),  # real change -> 800 kbit/s
+    ]
+    rates = []
+    for byte_count, ts in samples:
+        calc.add_sample(byte_count, ts)
+        rates.append(calc.rate_kbps)
+    # After the first real change, every subsequent reading is the real rate.
+    assert rates == [0.0, 0.0, 800.0, 800.0, 800.0]
+
+
+def test_rate_calculator_zeros_when_stale() -> None:
+    """An interface idle past the stale threshold is driven to 0."""
+    calc = RateCalculator(stale_threshold_seconds=300.0)
+    calc.add_sample(0, 0.0)
+    calc.add_sample(125_000, 1.0)
+    assert calc.rate_kbps == 1000.0
+    # No counter movement for longer than the stale window.
+    calc.add_sample(125_000, 400.0)
+    assert calc.rate_kbps == 0.0
+
+
+def test_rate_calculator_handles_counter_wrap() -> None:
+    """A 32-bit counter wrap is treated as a positive delta, not a negative one."""
+    calc = RateCalculator()
+    calc.add_sample(RateCalculator.COUNTER_32_MAX - 1000, 0.0)
+    calc.add_sample(0, 1.0)  # wrapped: delta = 1000 bytes
+    assert calc.rate_kbps == 1000 * 8 / 1000


### PR DESCRIPTION
## Summary

Network RX/TX rate sensors intermittently report **0 kbit/s**, flapping between the correct value and 0 (and occasionally large spikes). This makes per-interface bandwidth sensors unusable for monitoring/automation.

## Root cause

`RateCalculator.add_sample()` recomputes the rate on **every** sample and writes the result unconditionally:

```python
delta_bytes = byte_count - self._last_bytes   # == 0 when the counter hasn't moved
...
self._rate_kbps = (delta_bytes / dt) * 8 / 1000   # -> 0
```

The HA `DataUpdateCoordinator` polls faster (~30s) than the agent refreshes its network byte counters (`INTERVAL_NETWORK`, ~60s). So on roughly every other poll the counter is unchanged, `delta_bytes == 0`, and the rate is overwritten with `0`. The sensor then alternates between the real rate and `0`.

## Fix

When the counter hasn't advanced since the last sample (`delta_bytes == 0`), **hold the previous rate and keep the baseline** instead of writing a `0`. The next real change is then measured over the true elapsed interval. A genuinely idle interface is still driven to `0` by the existing `stale_threshold` branch once `dt` grows past the threshold, so idle behaviour is preserved.

The byte counter itself is reliable; only the sampling cadence caused the false zeros, so this is fixed at the source in `RateCalculator` (which benefits every rate sensor that uses it).

## Why this is a regression (and won't come back)

This exact symptom was fixed before in `262b303` ("Fix network sensor rate calculation showing incorrect 0 values"), which guarded the **inline** rate calc in `sensor.py` ("only recompute when the counter changed"). The later refactor `28f7b3c` ("vendor API client and harden integration quality") moved rate logic out of `sensor.py` into the new `RateCalculator` and did not carry that guard forward, silently re-introducing the bug.

There was no regression test pinning the behaviour, so nothing caught it. This PR adds `tests/test_calculators.py` covering:

- steady rate with fast polling (no 0/value flapping),
- holding the rate (and baseline) on an unchanged counter,
- zeroing once past the stale threshold,
- 32-bit counter wrap.

So a future refactor that drops the guard will fail the suite.

## Testing

- New unit tests in `tests/test_calculators.py`.
- Verified live on Home Assistant `2026.6.4` against a real agent: WLAN RX/TX sensors stopped flapping to 0 and now report steady, accurate values matching the interface's actual throughput.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed rate calculation incorrectly resetting to zero when the system polled faster than the underlying data source could update.

* **Tests**
  * Added comprehensive test suite for rate calculation functionality, including edge cases and counter wrap-around scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->