### PR TITLE
fix(sensor): stop the uptime sensor flapping the boot timestamp

### DIFF
--- a/custom_components/unraid_management_agent/sensor.py
+++ b/custom_components/unraid_management_agent/sensor.py
@@ -1626,6 +1626,46 @@ class UnraidSensorEntity(UnraidBaseEntity, SensorEntity):
         return self.entity_description.available_fn(self.coordinator.data)
 
 
+class UnraidUptimeSensorEntity(UnraidSensorEntity):
+    """
+    Uptime sensor that stabilizes the derived boot timestamp.
+
+    The boot time is derived as ``now() - uptime_seconds``. Because ``now()``
+    advances continuously while ``uptime_seconds`` is whole-second quantized and
+    only changes when the daemon refreshes its data, the raw value drifts by a
+    second or two on every coordinator update, spamming the logbook with a
+    "changed" event on each refresh (the daemon pushes updates roughly once a
+    second over WebSocket). Hold the last reported boot time and only move it
+    when it drifts beyond a small tolerance, so a genuine reboot still registers
+    while refresh jitter does not.
+    """
+
+    _BOOT_TIME_TOLERANCE = timedelta(seconds=30)
+
+    def __init__(
+        self,
+        coordinator: UnraidDataUpdateCoordinator,
+        description: UnraidSensorEntityDescription,
+    ) -> None:
+        """Initialize the uptime sensor."""
+        super().__init__(coordinator, description)
+        self._boot_time: datetime | None = None
+
+    @property
+    def native_value(self) -> Any:
+        """Return a boot timestamp that is stable across refresh jitter."""
+        boot_time = super().native_value
+        if not isinstance(boot_time, datetime):
+            self._boot_time = None
+            return boot_time
+        if (
+            self._boot_time is None
+            or abs(boot_time - self._boot_time) > self._BOOT_TIME_TOLERANCE
+        ):
+            self._boot_time = boot_time
+        return self._boot_time
+
+
 class UnraidSystemStatusSensor(UnraidBaseEntity, SensorEntity):
     """High-level system status sensor for shutdown and reboot visibility."""
 
@@ -3467,7 +3507,10 @@ async def async_setup_entry(
     # System sensors (always enabled - system collector is required)
     for description in SYSTEM_SENSOR_DESCRIPTIONS:
         if description.supported_fn(data):
-            entities.append(UnraidSensorEntity(coordinator, description))
+            if description.key == "uptime":
+                entities.append(UnraidUptimeSensorEntity(coordinator, description))
+            else:
+                entities.append(UnraidSensorEntity(coordinator, description))
 
     entities.append(UnraidSystemStatusSensor(coordinator))
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,6 +35,7 @@ from custom_components.unraid_management_agent.sensor import (
     UnraidSensorEntity,
     UnraidShareUsageSensor,
     UnraidUPSEnergySensor,
+    UnraidUptimeSensorEntity,
     UnraidZFSPoolHealthSensor,
     UnraidZFSPoolUsageSensor,
     # Value functions for testing
@@ -495,6 +496,56 @@ def test_get_uptime_attrs_none_data():
     """Test _get_uptime_attrs with None data."""
     attrs = _get_uptime_attrs(None)
     assert attrs == {}
+
+
+def _make_uptime_entity(uptime_seconds: int | None) -> UnraidUptimeSensorEntity:
+    """Build an uptime entity backed by a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = MagicMock(spec=UnraidData)
+    coordinator.data.system = MagicMock()
+    coordinator.data.system.uptime_seconds = uptime_seconds
+    description = next(d for d in SYSTEM_SENSOR_DESCRIPTIONS if d.key == "uptime")
+    return UnraidUptimeSensorEntity(coordinator, description)
+
+
+def test_uptime_entity_ignores_refresh_jitter():
+    """Boot timestamp stays put when now() drifts but uptime is unchanged."""
+    entity = _make_uptime_entity(86400)
+    with patch(
+        "custom_components.unraid_management_agent.sensor.dt_util.now"
+    ) as mock_now:
+        mock_now.return_value = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        first = entity.native_value
+        mock_now.return_value = datetime(2026, 1, 1, 12, 0, 2, tzinfo=UTC)
+        second = entity.native_value
+    assert isinstance(first, datetime)
+    assert first == second
+
+
+def test_uptime_entity_tracks_reboot():
+    """A real reboot moves the boot timestamp beyond the tolerance."""
+    entity = _make_uptime_entity(86400)
+    with patch(
+        "custom_components.unraid_management_agent.sensor.dt_util.now"
+    ) as mock_now:
+        mock_now.return_value = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        first = entity.native_value
+        entity.coordinator.data.system.uptime_seconds = 60
+        second = entity.native_value
+    assert second > first
+
+
+def test_uptime_entity_passthrough_none():
+    """A missing uptime value passes through and resets the cache."""
+    entity = _make_uptime_entity(86400)
+    with patch(
+        "custom_components.unraid_management_agent.sensor.dt_util.now"
+    ) as mock_now:
+        mock_now.return_value = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        assert isinstance(entity.native_value, datetime)
+        entity.coordinator.data.system.uptime_seconds = None
+        assert entity.native_value is None
+        assert entity._boot_time is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

The **Uptime** sensor exposes a boot timestamp derived as `now() - uptime_seconds`, recomputed in `native_value` on every coordinator update. Because `now()` advances continuously while `uptime_seconds` is whole-second quantized (and only changes when the daemon refreshes), the derived boot timestamp drifts by a second or two on every update.

With the WebSocket pushing updates roughly once a second, the timestamp changed on essentially every push — so Home Assistant logged a `Uptime changed to …` entry **every second**, flooding the logbook and recorder. Raising `UPDATE_INTERVAL` doesn't help while the WebSocket is enabled, since each push re-evaluates the value.

## Fix

Add `UnraidUptimeSensorEntity`, a thin `UnraidSensorEntity` subclass that holds the last reported boot time and only moves it when it drifts beyond a **30s tolerance**. A genuine reboot still registers (the boot time jumps far beyond the tolerance), while ordinary refresh jitter is absorbed. This mirrors how HA core's `systemmonitor` "Last Boot" sensor stabilizes the same `now() - uptime` derivation.

State is held per entity, so multiple Unraid instances never interfere with each other.

The raw `_get_uptime` value function is unchanged; only the entity that surfaces it gains stabilization, and it's wired in `async_setup_entry` the same way the other specialized system entities are.

## Tests

`tests/test_sensor.py` gains coverage for:
- jitter suppression (boot time unchanged when `now()` advances but uptime is steady)
- reboot tracking (boot time moves when uptime resets)
- `None` passthrough / cache reset when uptime is unavailable

`ruff check` and `ruff format --check` pass on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of the uptime sensor by reducing unnecessary update notifications caused by timing drift, providing a more consistent monitoring experience.

* **Tests**
  * Added comprehensive test coverage for uptime sensor stability and reboot detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->